### PR TITLE
feat(modals): add edit subject and edit class in Schedule

### DIFF
--- a/src/components/Common/DataTable.vue
+++ b/src/components/Common/DataTable.vue
@@ -49,7 +49,7 @@
   <!-- Table -->
   <div class="mt-3 shadow-sm" id="datatable">
     <CTable responsive :hover="!isLoading && datas.length > 0" class="m-0">
-      <CTableHead color="light">
+      <CTableHead color="light" v-if="!hideHeader">
         <CTableRow>
           <CTableHeaderCell
             v-if="!hideIndex"
@@ -137,6 +137,7 @@
                 <div class="d-flex align-items-center">
                   <slot name="actions(view)" :data="data">
                     <CButton
+                      v-if="hasView"
                       color="light"
                       shape="rounded-pill"
                       @click="handleCellClick(data)"
@@ -172,6 +173,22 @@
               </slot>
             </CTableDataCell>
           </CTableRow>
+          <CTableRow v-if="hasAdd">
+            <CTableDataCell
+              class="text-center"
+              :colspan="columns.length + (hideActions ? 0 : 1)"
+            >
+              <CButton
+                @click="handleAddClick"
+                type="button"
+                color="success"
+                shape="rounded-pill"
+                class="ms-2 text-light"
+              >
+                <font-awesome-icon icon="fa-solid fa-plus" />
+              </CButton>
+            </CTableDataCell>
+          </CTableRow>
         </template>
 
         <template v-else>
@@ -181,7 +198,7 @@
                 <Loading />
               </template>
               <template v-if="!isLoading && datas.length < 1">
-                <div class="text-center">NoData</div>
+                <div class="text-center">No Data</div>
               </template>
             </CTableHeaderCell>
           </CTableRow>
@@ -269,6 +286,11 @@ export default {
       type: Array,
       required: false,
     },
+    hasView: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
     hasEdit: {
       type: Boolean,
       required: false,
@@ -279,7 +301,17 @@ export default {
       required: false,
       default: false,
     },
+    hasAdd: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
     clickable: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    hideHeader: {
       type: Boolean,
       required: false,
       default: false,
@@ -355,6 +387,11 @@ export default {
         this.$emit('viewClick', cell)
       }
     },
+    handleViewClick(cell) {
+      if (this.hasView) {
+        this.$emit('viewClick', cell)
+      }
+    },
     handleEditClick(cell) {
       if (this.hasEdit) {
         this.$emit('editClick', cell)
@@ -363,6 +400,11 @@ export default {
     handleDeleteClick(cell) {
       if (this.hasDelete) {
         this.$emit('deleteClick', cell)
+      }
+    },
+    handleAddClick() {
+      if (this.hasAdd) {
+        this.$emit('addClick')
       }
     },
     onSubmit(values) {
@@ -406,11 +448,11 @@ export default {
 </script>
 
 <style scoped>
-#datatable {
-  max-height: 50vh;
-}
-
 thead > tr > th {
   top: 0;
+}
+
+td {
+  padding: 8px 4px 8px 4px;
 }
 </style>

--- a/src/components/Common/DataTable.vue
+++ b/src/components/Common/DataTable.vue
@@ -252,7 +252,7 @@ export default {
     Pagination,
     ItemsPerPageSelect,
   },
-  emits: ['viewClick', 'editClick', 'deleteClick'],
+  emits: ['viewClick', 'editClick', 'deleteClick', 'addClick'],
   props: {
     columns: {
       type: Array,

--- a/src/components/Modals/EditClassModal.vue
+++ b/src/components/Modals/EditClassModal.vue
@@ -3,9 +3,18 @@
     <CForm>
       <CModalBody>
         <CRow class="mb-4">
-          <CCol sm="3" class="py-1 fw-semibold"> Class ID </CCol>
-          <CCol sm="3" class="py-1 border rounded">
-            {{ data.class_code }}
+          <CCol sm="3">
+            <CFormLabel for="classId" class="col-form-label fw-semibold">
+              Class ID
+            </CFormLabel>
+          </CCol>
+          <CCol sm="3">
+            <CFormInput
+              type="text"
+              id="classId"
+              :value="data.class_code"
+              required
+            />
           </CCol>
         </CRow>
         <DataTable
@@ -91,7 +100,6 @@ export default {
     }
   },
   methods: {
-    // modal edit class
     setColumns() {
       this.columns = [
         { data: 'time', title: '' },

--- a/src/components/Modals/EditClassModal.vue
+++ b/src/components/Modals/EditClassModal.vue
@@ -1,0 +1,141 @@
+<template>
+  <CModal :visible="isVisible" @click="emitClose">
+    <CForm>
+      <CModalBody>
+        <CRow class="mb-4">
+          <CCol sm="3" class="py-1 fw-semibold"> Class ID </CCol>
+          <CCol sm="3" class="py-1 border rounded">
+            {{ data.class_code }}
+          </CCol>
+        </CRow>
+        <DataTable
+          :columns="columns"
+          :datas="data.time"
+          hideFilters
+          hideItemPerPageSelector
+          hidePagination
+          hideIndex
+          hideHeader
+          @deleteClick="handleDeleteTime"
+          hasDelete="true"
+          @addClick="handleAddTime"
+          hasAdd="true"
+        >
+          <template #column(time)="">
+            <p class="m-0 fw-semibold">Time</p>
+          </template>
+          <template #column(day)="{ value }">
+            <CFormSelect class="class-day" required>
+              <option
+                v-for="option in dayOption"
+                :key="option.value"
+                :value="option.value"
+                :selected="option.label === value"
+              >
+                {{ option.label }}
+              </option>
+            </CFormSelect>
+          </template>
+          <template #column(startTime)="{ value }">
+            <CFormInput type="time" :value="value" required />
+          </template>
+          <template #column(~)="">
+            <span>~</span>
+          </template>
+          <template #column(endTime)="{ value }">
+            <CFormInput type="time" :value="value" required />
+          </template>
+        </DataTable>
+      </CModalBody>
+      <CModalFooter class="d-flex justify-content-between">
+        <CButton color="secondary" variant="outline" @click="emitClose"
+          >Cancel</CButton
+        >
+        <CButton type="submit" color="primary" @click="handleDone"
+          >Done</CButton
+        >
+      </CModalFooter>
+    </CForm>
+  </CModal>
+</template>
+
+<script>
+import { ref } from '@vue/reactivity'
+import DataTable from '@/components/Common/DataTable.vue'
+
+export default {
+  name: 'EditClassModal',
+  props: [],
+  components: {
+    DataTable,
+  },
+  setup() {
+    const data = ref([])
+    const columns = ref([])
+    const isVisible = ref(false)
+    const dayOption = [
+      { label: 'Mon', value: '1' },
+      { label: 'Tue', value: '2' },
+      { label: 'Wed', value: '3' },
+      { label: 'Thu', value: '4' },
+      { label: 'Fri', value: '5' },
+      { label: 'Sat', value: '6' },
+      { label: 'Sun', value: '7' },
+    ]
+
+    return {
+      columns,
+      data,
+      dayOption,
+      isVisible,
+    }
+  },
+  methods: {
+    // modal edit class
+    setColumns() {
+      this.columns = [
+        { data: 'time', title: '' },
+        { data: 'day', title: 'Day' },
+        { data: 'startTime', title: 'Start Time' },
+        { data: '~', title: '' },
+        { data: 'endTime', title: 'End Time' },
+      ]
+    },
+    setDatas() {
+      this.data = {
+        class_code: 'IT123',
+        time: [
+          { day: 'Wed', startTime: '06:45', endTime: '09:00' },
+          { day: 'Tue', startTime: '06:45', endTime: '09:00' },
+        ],
+      }
+    },
+    emitClose() {
+      this.$emit('close')
+    },
+    handleDeleteTime(time) {
+      this.data.time = this.data.time.filter((t) => t !== time)
+    },
+    handleAddTime() {
+      this.data.time.push({
+        day: '',
+        startTime: '',
+        endTime: '',
+      })
+    },
+    handleDone() {
+      console.log('done')
+    },
+  },
+  created() {
+    this.setColumns()
+    this.setDatas()
+  },
+}
+</script>
+
+<style scoped>
+.class-day {
+  min-width: 82px;
+}
+</style>

--- a/src/components/Modals/EditSubjectModal.vue
+++ b/src/components/Modals/EditSubjectModal.vue
@@ -1,0 +1,136 @@
+<template>
+  <CModal :visible="isVisible" @click="emitClose">
+    <CForm>
+      <CModalBody>
+        <CRow class="mb-4">
+          <CCol class="col-sm-3 py-1 ps-3 fw-semibold"> Subject </CCol>
+          <CCol class="col-sm-6 py-1 border rounded">
+            {{ data.subject }}
+          </CCol>
+        </CRow>
+        <DataTable
+          :columns="columns"
+          :datas="data.classes"
+          hideFilters
+          hideItemPerPageSelector
+          hidePagination
+          hideIndex
+          clickable
+          @editClick="handleEditClass"
+          hasEdit="true"
+          @deleteClick="handleDeleteClass"
+          hasDelete="true"
+          @addClick="handleAddClass"
+          hasAdd="true"
+        >
+          <template #column(time)="{ value }">
+            <p class="m-0" v-for="data in value" :key="data.time">
+              {{ data.day }} {{ data.startTime }}-{{ data.endTime }}
+            </p>
+          </template>
+        </DataTable>
+      </CModalBody>
+      <CModalFooter class="d-flex justify-content-between">
+        <CButton color="secondary" variant="outline" @click="emitClose">
+          Cancel
+        </CButton>
+        <CButton type="submit" color="primary" @click="handleDone">
+          Done
+        </CButton>
+      </CModalFooter>
+    </CForm>
+  </CModal>
+</template>
+
+<script>
+import { ref } from '@vue/reactivity'
+import DataTable from '@/components/Common/DataTable.vue'
+
+export default {
+  name: 'EditSubjectModal',
+  props: [],
+  components: {
+    DataTable,
+  },
+  setup() {
+    const data = ref([])
+    const columns = ref([])
+    const isVisible = ref(false)
+    const showEditClassModal = ref(false)
+    return {
+      columns,
+      data,
+      isVisible,
+      showEditClassModal,
+    }
+  },
+  methods: {
+    setColumns() {
+      this.columns = [
+        { data: 'class_code', title: 'Class Code' },
+        { data: 'time', title: 'Time' },
+      ]
+    },
+    setData() {
+      this.data = {
+        subject: 'C Basic',
+        classes: [
+          {
+            class_code: 'IT123',
+            time: [
+              { day: 'Mon', startTime: '06:45', endTime: '09:00' },
+              { day: 'Wed', startTime: '06:45', endTime: '09:00' },
+            ],
+          },
+          {
+            class_code: 'IT123',
+            time: [
+              { day: 'Tue', startTime: '06:45', endTime: '09:00' },
+              { day: 'Thu', startTime: '06:45', endTime: '09:00' },
+            ],
+          },
+        ],
+      }
+    },
+    emitClose() {
+      this.$emit('close')
+    },
+    emitEditClass() {
+      this.$emit('editClass')
+    },
+    toggleIsVisible() {
+      this.isVisible = !this.isVisible
+    },
+    toggleShowEditClassModal() {
+      this.showEditClassModal = !this.showEditClassModal
+    },
+    handleEditClass() {
+      this.emitEditClass()
+      this.emitClose()
+    },
+    handleDeleteClass(_class) {
+      this.data.classes = this.data.classes.filter((c) => c !== _class)
+    },
+    handleAddClass() {
+      this.data.classes.push({
+        subject: 'new',
+        classes: [
+          {
+            class_code: '...',
+            time: [],
+          },
+        ],
+      })
+    },
+    handleDone() {
+      console.log('done')
+    },
+  },
+  created() {
+    this.setColumns()
+    this.setData()
+  },
+}
+</script>
+
+<style></style>

--- a/src/components/Modals/EditSubjectModal.vue
+++ b/src/components/Modals/EditSubjectModal.vue
@@ -3,9 +3,18 @@
     <CForm>
       <CModalBody>
         <CRow class="mb-4">
-          <CCol class="col-sm-3 py-1 ps-3 fw-semibold"> Subject </CCol>
-          <CCol class="col-sm-6 py-1 border rounded">
-            {{ data.subject }}
+          <CCol sm="3">
+            <CFormLabel for="subject" class="col-form-label fw-semibold">
+              Subject
+            </CFormLabel>
+          </CCol>
+          <CCol sm="6">
+            <CFormInput
+              type="text"
+              id="subject"
+              :value="data.subject"
+              required
+            />
           </CCol>
         </CRow>
         <DataTable

--- a/src/views/schedule/Schedule.vue
+++ b/src/views/schedule/Schedule.vue
@@ -49,6 +49,7 @@
         hideIndex
         clickable
         @viewClick="handleView"
+        hasView="true"
         @editClick="handleEdit"
         hasEdit="true"
         @deleteClick="handleDelete"
@@ -61,32 +62,49 @@
         </template>
         <template #column(time)="{ value }">
           <p class="m-0" v-for="data in value" :key="data.time">
-            {{ data.time }}
+            {{ data.day }} {{ data.startTime }}-{{ data.endTime }}
           </p>
         </template>
       </DataTable>
     </CCardBody>
   </CCard>
+
+  <div>
+    <EditSubjectModal
+      :visible="showEditSubjectModal"
+      @close="toggleEditSubject"
+      @editClass="toggleEditClass"
+    />
+
+    <EditClassModal :visible="showEditClassModal" @close="toggleEditClass" />
+  </div>
 </template>
 
 <script>
 import { ref } from '@vue/reactivity'
 import DataTable from '@/components/Common/DataTable.vue'
+import EditSubjectModal from '@/components/Modals/EditSubjectModal.vue'
+import EditClassModal from '@/components/Modals/EditClassModal.vue'
 
 export default {
   name: 'Schedule',
   components: {
     DataTable,
+    EditSubjectModal,
+    EditClassModal,
   },
   setup() {
     const value = ref({})
     const datas = ref([])
     const columns = ref([])
-
+    const showEditSubjectModal = ref(false)
+    const showEditClassModal = ref(false)
     return {
       value,
       datas,
       columns,
+      showEditSubjectModal,
+      showEditClassModal,
     }
   },
   methods: {
@@ -100,19 +118,28 @@ export default {
     setDatas() {
       this.datas = [
         {
-          subject: 'C BAsic',
+          subject: 'C Basic',
           class_code: [{ name: 'IT123' }, { name: 'IT122' }],
-          time: [{ time: 'Wed 6h-9h' }, { time: 'Wed 6h-9h' }],
+          time: [
+            { day: 'Wed', startTime: '06:45', endTime: '09:00' },
+            { day: 'Tue', startTime: '06:45', endTime: '09:00' },
+          ],
         },
         {
-          subject: 'C BAsic',
+          subject: 'C Basic',
           class_code: [{ name: 'IT123' }, { name: 'IT122' }],
-          time: [{ time: 'Wed 6h-9h' }, { time: 'Wed 6h-9h' }],
+          time: [
+            { day: 'Wed', startTime: '06:45', endTime: '09:00' },
+            { day: 'Tue', startTime: '06:45', endTime: '09:00' },
+          ],
         },
         {
-          subject: 'C BAsic',
+          subject: 'C Basic',
           class_code: [{ name: 'IT123' }, { name: 'IT122' }],
-          time: [{ time: 'Wed 6h-9h' }, { time: 'Wed 6h-9h' }],
+          time: [
+            { day: 'Wed', startTime: '06:45', endTime: '09:00' },
+            { day: 'Tue', startTime: '06:45', endTime: '09:00' },
+          ],
         },
       ]
     },
@@ -121,10 +148,20 @@ export default {
     },
     handleEdit() {
       console.log('edit')
+      this.toggleEditSubject()
+      this.editedSubject = {}
     },
     handleDelete() {
       console.log('delete')
     },
+    toggleEditSubject() {
+      this.showEditSubjectModal = !this.showEditSubjectModal
+    },
+    toggleEditClass() {
+      this.toggleEditSubject()
+      this.showEditClassModal = !this.showEditClassModal
+    },
+
     async fetchLanguages(query) {
       // From: https://www.back4app.com/database/paul-datasets/list-of-all-programming-languages/get-started/javascript/rest-api/fetch?objectClassSlug=dataset
 
@@ -172,3 +209,5 @@ export default {
   },
 }
 </script>
+
+<style></style>


### PR DESCRIPTION
**Change:**

**components/Common/DataTable:**
- add: hasView, hasAdd, hideHeader, style for tag td
- remove: style (max-height) for #datatable

**components/Modals:**
- add: EditClassModal, EditSubjectModal

**view/Schedule:**
- add: use the 2 two above Modals
- change: class time format

--------------------------

**Demo:**

Edit Subject Modal:
<img width="1440" alt="Screenshot 2022-12-06 at 04 08 42" src="https://user-images.githubusercontent.com/61821744/205743167-5199ce05-7b27-47db-8bc8-22cb13d79b34.png">

Edit Class Modal:
<img width="1440" alt="Screenshot 2022-12-06 at 04 09 12" src="https://user-images.githubusercontent.com/61821744/205743237-cfcba20d-0b62-4923-94a5-2f946bfe4135.png">
