### PR TITLE
refactor(modals): use store for toggle modal and get data

### DIFF
--- a/src/components/Modals/EditClassModal.vue
+++ b/src/components/Modals/EditClassModal.vue
@@ -1,17 +1,17 @@
 <template>
-  <CModal :visible="isVisible" @click="emitClose">
+  <CModal @click="emitClose">
     <CForm>
       <CModalBody>
         <CRow class="mb-4">
           <CCol sm="3">
-            <CFormLabel for="classId" class="col-form-label fw-semibold">
+            <CFormLabel for="classCode" class="col-form-label fw-semibold">
               Class ID
             </CFormLabel>
           </CCol>
           <CCol sm="3">
             <CFormInput
               type="text"
-              id="classId"
+              id="classCode"
               :value="data.class_code"
               required
             />
@@ -74,14 +74,12 @@ import DataTable from '@/components/Common/DataTable.vue'
 
 export default {
   name: 'EditClassModal',
-  props: [],
   components: {
     DataTable,
   },
   setup() {
     const data = ref([])
     const columns = ref([])
-    const isVisible = ref(false)
     const dayOption = [
       { label: 'Mon', value: '1' },
       { label: 'Tue', value: '2' },
@@ -96,7 +94,6 @@ export default {
       columns,
       data,
       dayOption,
-      isVisible,
     }
   },
   methods: {
@@ -125,11 +122,7 @@ export default {
       this.data.time = this.data.time.filter((t) => t !== time)
     },
     handleAddTime() {
-      this.data.time.push({
-        day: '',
-        startTime: '',
-        endTime: '',
-      })
+      this.data.time.push({ day: '', startTime: '', endTime: '' })
     },
     handleDone() {
       this.emitClose()

--- a/src/components/Modals/EditClassModal.vue
+++ b/src/components/Modals/EditClassModal.vue
@@ -5,14 +5,14 @@
         <CRow class="mb-4">
           <CCol sm="3">
             <CFormLabel for="classCode" class="col-form-label fw-semibold">
-              Class ID
+              Class Code
             </CFormLabel>
           </CCol>
           <CCol sm="3">
             <CFormInput
               type="text"
               id="classCode"
-              :value="data.class_code"
+              :value="data.classCode"
               required
             />
           </CCol>
@@ -70,6 +70,8 @@
 
 <script>
 import { ref } from '@vue/reactivity'
+// import { computed } from 'vue'
+// import { useStore } from 'vuex'
 import DataTable from '@/components/Common/DataTable.vue'
 
 export default {
@@ -78,6 +80,7 @@ export default {
     DataTable,
   },
   setup() {
+    // const store = useStore()
     const data = ref([])
     const columns = ref([])
     const dayOption = [
@@ -107,12 +110,14 @@ export default {
       ]
     },
     setDatas() {
-      this.data = {
-        class_code: 'IT123',
-        time: [
-          { day: 'Wed', startTime: '06:45', endTime: '09:00' },
-          { day: 'Tue', startTime: '06:45', endTime: '09:00' },
-        ],
+      let editedClassCode = this.$store.getters.editedClassCode
+      if (editedClassCode) {
+        this.data = this.$store.getters.getEditedClass
+      } else {
+        this.data = {
+          classCode: '',
+          time: [{ day: '', startTime: '', endTime: '' }],
+        }
       }
     },
     emitClose() {
@@ -129,9 +134,16 @@ export default {
       console.log('done')
     },
   },
-  created() {
+  async created() {
     this.setColumns()
     this.setDatas()
+  },
+  watch: {
+    '$store.getters.editedClassCode': {
+      handler: function () {
+        this.setDatas()
+      },
+    },
   },
 }
 </script>

--- a/src/components/Modals/EditSubjectModal.vue
+++ b/src/components/Modals/EditSubjectModal.vue
@@ -12,7 +12,7 @@
             <CFormInput
               type="text"
               id="subjectName"
-              :value="data.subject"
+              :value="data.subjectName"
               required
             />
           </CCol>
@@ -33,7 +33,7 @@
           :hasAdd="true"
         >
           <template #column(time)="{ value }">
-            <p class="m-0" v-for="data in value" :key="data.time">
+            <p class="m-0" v-for="data in value" :key="data">
               {{ data.day }} {{ data.startTime }}-{{ data.endTime }}
             </p>
           </template>
@@ -53,6 +53,8 @@
 
 <script>
 import { ref } from '@vue/reactivity'
+import { computed } from 'vue'
+import { useStore } from 'vuex'
 import DataTable from '@/components/Common/DataTable.vue'
 
 export default {
@@ -61,42 +63,28 @@ export default {
     DataTable,
   },
   setup() {
+    const store = useStore()
     const data = ref([])
     const columns = ref([])
-    const showEditClassModal = ref(false)
+    const classes = ref([])
+
     return {
       columns,
       data,
-      showEditClassModal,
+      showEditClassModal: computed(() => store.getters.showEditClassModal),
+      classes,
+      editedSubject: computed(() => store.getters.editedSubject),
     }
   },
   methods: {
     setColumns() {
       this.columns = [
-        { data: 'class_code', title: 'Class Code' },
+        { data: 'classCode', title: 'Class Code' },
         { data: 'time', title: 'Time' },
       ]
     },
-    setData() {
-      this.data = {
-        subject: 'C Basic',
-        classes: [
-          {
-            class_code: 'IT123',
-            time: [
-              { day: 'Mon', startTime: '06:45', endTime: '09:00' },
-              { day: 'Wed', startTime: '06:45', endTime: '09:00' },
-            ],
-          },
-          {
-            class_code: 'IT123',
-            time: [
-              { day: 'Tue', startTime: '06:45', endTime: '09:00' },
-              { day: 'Thu', startTime: '06:45', endTime: '09:00' },
-            ],
-          },
-        ],
-      }
+    setDatas() {
+      this.data = this.$store.getters.getEditedSubject
     },
     emitClose() {
       this.$emit('close')
@@ -105,16 +93,18 @@ export default {
       this.$emit('editClass')
     },
     toggleShowEditClassModal() {
-      this.showEditClassModal = !this.showEditClassModal
+      this.$store.dispatch('toggleEditClass')
     },
-    handleEditClass() {
-      this.emitEditClass()
+    handleEditClass(_class) {
+      this.$store.dispatch('setEditedClassCode', _class.classCode)
+      this.toggleShowEditClassModal()
     },
     handleDeleteClass(_class) {
       this.data.classes = this.data.classes.filter((c) => c !== _class)
     },
     handleAddClass() {
-      console.log('add')
+      this.$store.dispatch('setEditedClassCode', null)
+      this.toggleShowEditClassModal()
     },
     handleDone() {
       this.emitClose()
@@ -123,7 +113,14 @@ export default {
   },
   created() {
     this.setColumns()
-    this.setData()
+    this.setDatas()
+  },
+  watch: {
+    '$store.getters.editedSubjectID': {
+      handler: function () {
+        this.setDatas()
+      },
+    },
   },
 }
 </script>

--- a/src/components/Modals/EditSubjectModal.vue
+++ b/src/components/Modals/EditSubjectModal.vue
@@ -1,17 +1,17 @@
 <template>
-  <CModal :visible="isVisible" @click="emitClose">
+  <CModal @click="emitClose">
     <CForm>
       <CModalBody>
         <CRow class="mb-4">
           <CCol sm="3">
-            <CFormLabel for="subject" class="col-form-label fw-semibold">
+            <CFormLabel for="subjectName" class="col-form-label fw-semibold">
               Subject
             </CFormLabel>
           </CCol>
           <CCol sm="6">
             <CFormInput
               type="text"
-              id="subject"
+              id="subjectName"
               :value="data.subject"
               required
             />
@@ -26,11 +26,11 @@
           hideIndex
           clickable
           @editClick="handleEditClass"
-          hasEdit="true"
+          :hasEdit="true"
           @deleteClick="handleDeleteClass"
-          hasDelete="true"
+          :hasDelete="true"
           @addClick="handleAddClass"
-          hasAdd="true"
+          :hasAdd="true"
         >
           <template #column(time)="{ value }">
             <p class="m-0" v-for="data in value" :key="data.time">
@@ -57,19 +57,16 @@ import DataTable from '@/components/Common/DataTable.vue'
 
 export default {
   name: 'EditSubjectModal',
-  props: [],
   components: {
     DataTable,
   },
   setup() {
     const data = ref([])
     const columns = ref([])
-    const isVisible = ref(false)
     const showEditClassModal = ref(false)
     return {
       columns,
       data,
-      isVisible,
       showEditClassModal,
     }
   },
@@ -107,29 +104,17 @@ export default {
     emitEditClass() {
       this.$emit('editClass')
     },
-    toggleIsVisible() {
-      this.isVisible = !this.isVisible
-    },
     toggleShowEditClassModal() {
       this.showEditClassModal = !this.showEditClassModal
     },
     handleEditClass() {
       this.emitEditClass()
-      this.emitClose()
     },
     handleDeleteClass(_class) {
       this.data.classes = this.data.classes.filter((c) => c !== _class)
     },
     handleAddClass() {
-      this.data.classes.push({
-        subject: 'new',
-        classes: [
-          {
-            class_code: '...',
-            time: [],
-          },
-        ],
-      })
+      console.log('add')
     },
     handleDone() {
       this.emitClose()

--- a/src/store/subject.js
+++ b/src/store/subject.js
@@ -3,63 +3,136 @@ export default {
     subjects: [
       {
         id: 1,
-        subject_name: 'Cbasic',
-        subject_code: 'IT12',
-        class: [
+        subjectName: 'C Intro',
+        subjectCode: 'IT123',
+        classes: [
           {
-            class_id: 'IT123',
+            classCode: '101001',
             time: [
-              {
-                day: 'wed',
-                start: '6h45',
-                end: '8h',
-              },
+              { day: 'Mon', startTime: '06:45', endTime: '08:00' },
+              { day: 'Tue', startTime: '06:45', endTime: '08:00' },
+            ],
+          },
+          {
+            classCode: '101002',
+            time: [
+              { day: 'Wed', startTime: '06:45', endTime: '08:00' },
+              { day: 'Thu', startTime: '06:45', endTime: '08:00' },
             ],
           },
         ],
       },
       {
         id: 2,
-        name: 'Cbasic',
-        subject_id: 'IT12',
-        class: [
+        subjectName: 'C Basic',
+        subjectCode: 'IT124',
+        classes: [
           {
-            classCode: 'IT123',
+            classCode: '101003',
             time: [
-              {
-                day: 'wed',
-                start: '6h45',
-                end: '8h',
-              },
+              { day: 'Mon', startTime: '06:45', endTime: '08:00' },
+              { day: 'Tue', startTime: '06:45', endTime: '08:00' },
+            ],
+          },
+          {
+            classCode: '101004',
+            time: [
+              { day: 'Wed', startTime: '06:45', endTime: '08:00' },
+              { day: 'Thu', startTime: '06:45', endTime: '08:00' },
             ],
           },
         ],
       },
       {
         id: 3,
-        name: 'Cbasic',
-        subject_id: 'IT12',
-        class: [
+        subjectName: 'C Advanced',
+        subjectCode: 'IT125',
+        classes: [
           {
-            classCode: 'IT123',
-            time: [
-              {
-                day: 'wed',
-                start: '6h45',
-                end: '8h',
-              },
-            ],
+            classCode: '101005',
+            time: [{ day: 'Tue', startTime: '06:45', endTime: '08:00' }],
+          },
+          {
+            classCode: '101006',
+            time: [{ day: 'Thu', startTime: '06:45', endTime: '08:00' }],
           },
         ],
       },
     ],
+    showEditSubjectModal: false,
+    showEditClassModal: false,
+    editedSubjectID: null,
+    editedClassCode: null,
   }),
   getters: {
     subjects(state) {
       return state.subjects
     },
+    reformatedSubject(state) {
+      let reformatedSubjects = []
+      let _classCode = []
+      let _time = []
+
+      state.subjects.forEach((subject) => {
+        subject.classes.forEach((c) => {
+          c.time.forEach((t, index) => {
+            _classCode.push(index === 0 ? c.classCode : ' ' + c.classCode)
+            _time.push(t)
+          })
+        })
+
+        reformatedSubjects.push({
+          id: subject.id,
+          subjectName: subject.subjectName,
+          subjectCode: subject.subjectCode,
+          classCode: _classCode,
+          time: _time,
+        })
+
+        _classCode = []
+        _time = []
+      })
+
+      // console.log(reformatedSubjects)
+      return reformatedSubjects
+    },
+    showEditSubjectModal(state) {
+      return state.showEditSubjectModal
+    },
+    showEditClassModal(state) {
+      return state.showEditClassModal
+    },
+    editedSubjectID(state) {
+      return state.editedSubjectID
+    },
+    editedClassCode(state) {
+      return state.editedClassCode
+    },
+    getEditedSubject(state) {
+      return state.subjects.find(
+        (subject) => subject.id === state.editedSubjectID,
+      )
+    },
+    getEditedClass(state, getters) {
+      return getters.getEditedSubject.classes.find(
+        (c) => c.classCode === state.editedClassCode,
+      )
+    },
   },
   mutations: {
+    setEditedSubjectID(state, value) {
+      state.editedSubjectID = value
+    },
+    setEditedClassCode(state, value) {
+      state.editedClassCode = value
+    },
+    toggleEditSubject(state) {
+      state.showEditSubjectModal = !state.showEditSubjectModal
+    },
+    toggleEditClass(state) {
+      state.showEditSubjectModal = !state.showEditSubjectModal
+      state.showEditClassModal = !state.showEditClassModal
+    },
     addSubject(state, value) {
       state.subjects.push(value)
     },
@@ -76,5 +149,18 @@ export default {
       state.subjects.slide(index, 1)
     },
   },
-  actions: {},
+  actions: {
+    setEditedSubjectID(context, payload) {
+      return context.commit('setEditedSubjectID', payload)
+    },
+    setEditedClassCode(context, payload) {
+      return context.commit('setEditedClassCode', payload)
+    },
+    toggleEditSubject(context) {
+      return context.commit('toggleEditSubject')
+    },
+    toggleEditClass(context) {
+      return context.commit('toggleEditClass')
+    },
+  },
 }

--- a/src/views/schedule/Schedule.vue
+++ b/src/views/schedule/Schedule.vue
@@ -57,9 +57,10 @@
         :hasDelete="true"
         @clickButton="clickDone"
       >
-        <template #column(class_code)="{ value }">
-          <p class="m-0" v-for="data in value" :key="data.name">
-            {{ data.name }} <br v-if="!data.name" />
+        <template #column(classCode)="{ value }">
+          <p class="m-0" v-for="data in value" :key="data">
+            <span v-if="data[0] != ' '">{{ data }}</span>
+            <br v-else />
           </p>
         </template>
         <template #column(time)="{ value }">
@@ -84,6 +85,8 @@
 
 <script>
 import { ref } from '@vue/reactivity'
+import { computed } from 'vue'
+import { useStore } from 'vuex'
 import DataTable from '@/components/Common/DataTable.vue'
 import EditSubjectModal from '@/components/Modals/EditSubjectModal.vue'
 import EditClassModal from '@/components/Modals/EditClassModal.vue'
@@ -96,63 +99,33 @@ export default {
     EditClassModal,
   },
   setup() {
+    const store = useStore()
     const value = ref({})
     const datas = ref([])
     const columns = ref([])
     const queries = ref({})
 
-    const showEditSubjectModal = ref(false)
-    const showEditClassModal = ref(false)
     return {
       value,
       datas,
       columns,
       queries,
-      showEditSubjectModal,
-      showEditClassModal,
+      showEditSubjectModal: computed(() => store.getters.showEditSubjectModal),
+      showEditClassModal: computed(() => store.getters.showEditClassModal),
+      editedSubjectID: computed(() => store.getters.editedSubjectID),
     }
   },
   methods: {
     setColumns() {
       this.columns = [
-        { data: 'subject', title: 'Subject' },
-        { data: 'class_code', title: 'Classcode' },
+        { data: 'subjectName', title: 'Subject' },
+        { data: 'classCode', title: 'Class Code' },
         { data: 'time', title: 'Time' },
       ]
     },
     setDatas() {
       this.pages = 10
-      this.datas = [
-        {
-          subject: 'C BAsic',
-          class_code: [
-            { name: 'IT123', endTime: 'Wed 6h-9h' },
-            { name: '', endTime: 'Thur 6h-9h' },
-            { name: 'IT122', endTime: 'Wed 6h-9h' },
-          ],
-          time: [
-            { day: '-Wed', startTime: '06:45', endTime: '09:00' },
-            { day: '-Wed', startTime: '06:45', endTime: '09:00' },
-            { day: 'Wed', startTime: '06:45', endTime: '09:00' },
-          ],
-        },
-        {
-          subject: 'C Basic',
-          class_code: [{ name: 'IT123' }, { name: 'IT122' }],
-          time: [
-            { day: 'Wed', startTime: '06:45', endTime: '09:00' },
-            { day: 'Tue', startTime: '06:45', endTime: '09:00' },
-          ],
-        },
-        {
-          subject: 'C Basic',
-          class_code: [{ name: 'IT123' }, { name: 'IT122' }],
-          time: [
-            { day: 'Wed', startTime: '06:45', endTime: '09:00' },
-            { day: 'Tue', startTime: '06:45', endTime: '09:00' },
-          ],
-        },
-      ]
+      this.datas = this.$store.getters.reformatedSubject
     },
     setQueries() {
       this.queries = this.$route.query
@@ -160,9 +133,9 @@ export default {
     handleView() {
       console.log('view')
     },
-    handleEdit() {
+    handleEdit(subject) {
+      this.$store.dispatch('setEditedSubjectID', subject.id)
       this.toggleEditSubject()
-      this.editedSubject = {}
     },
     handleDelete() {
       console.log('delete')
@@ -172,11 +145,10 @@ export default {
       this.$router.push({ name: 'ScheduleInfo' })
     },
     toggleEditSubject() {
-      this.showEditSubjectModal = !this.showEditSubjectModal
+      this.$store.dispatch('toggleEditSubject')
     },
     toggleEditClass() {
-      this.toggleEditSubject()
-      this.showEditClassModal = !this.showEditClassModal
+      this.$store.dispatch('toggleEditClass')
     },
 
     async fetchLanguages(query) {

--- a/src/views/schedule/Schedule.vue
+++ b/src/views/schedule/Schedule.vue
@@ -176,7 +176,6 @@ export default {
     },
     toggleEditClass() {
       this.toggleEditSubject()
-      console.log(this.showEditSubjectModal)
       this.showEditClassModal = !this.showEditClassModal
     },
 


### PR DESCRIPTION
### **Changes**

- Use `store/subject` for the toggles of modals, getters for `reformatedSubject`, `editedSubjectID`, `editedClassCode`
- Details about `reformatedSubject`:
  + Why needed? to fit the `subjects` into the format used by `components/Common/DataTable`

_The format of `subjects`:_
```
  subjects: [
        {
          id: 1,
          subjectName: 'C Intro',
          subjectCode: 'IT123',
          classes: [
            {
              classCode: '101001',
              time: [
                { day: 'Mon', startTime: '06:45', endTime: '08:00' },
                { day: 'Tue', startTime: '06:45', endTime: '08:00' },
              ],
            }, ...
          ...
          ],
        },
      ],
```
_The format of `reformatedSubject`:_
```
  reformatedSubject: [
        {
          id: 1,
          subjectName: 'C Intro',
          subjectCode: 'IT123',
          classCode: ['101001', ' 101001', '101002', ' 101002'], // those that has ' ' at the start will be hidden when rendering
          time: [
            { day: 'Wed', startTime: '06:45', endTime: '09:00' },
            { day: 'Tue', startTime: '06:45', endTime: '09:00' },
            { day: 'Wed', startTime: '06:45', endTime: '09:00' },
            { day: 'Tue', startTime: '06:45', endTime: '09:00' },
          ],
        }
      ],
```

### **Demo**
https://user-images.githubusercontent.com/61821744/206989198-84075157-9656-4505-bd3c-7a45fd1704f2.mov
